### PR TITLE
Fix terraform not using node name in aws resources

### DIFF
--- a/terraform/rocketpool/.terraform.lock.hcl
+++ b/terraform/rocketpool/.terraform.lock.hcl
@@ -2,22 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.10.0"
+  version     = "4.12.0"
   constraints = ">= 3.54.0, >= 3.63.0, >= 4.8.0"
   hashes = [
-    "h1:S6xGPRL08YEuBdemiYZyIBf/YwM4OCvzVuaiuU6kLjc=",
-    "zh:0a2a7eabfeb7dbb17b7f82aff3fa2ba51e836c15e5be4f5468ea44bd1299b48d",
-    "zh:23409c7205d13d2d68b5528e1c49e0a0455d99bbfec61eb0201142beffaa81f7",
-    "zh:3adad2245d97816f3919778b52c58fb2de130938a3e9081358bfbb72ec478d9a",
-    "zh:5bf100aba6332f24b1ffeae7536d5d489bb907bf774a06b95f2183089eaf1a1a",
-    "zh:63c3a24c0c229a1d3390e6ea2454ba4d8ace9b94e086bee1dbdcf665ae969e15",
-    "zh:6b76f5ffd920f0a750da3a4ff1d00eab18d9cd3731b009aae3df4135613bad4d",
-    "zh:8cd6b1e6b51e8e9bbe2944bb169f113d20d1d72d07ccd1b7b83f40b3c958233e",
+    "h1:JpUtuvOZSvLmwBg3/G1UtYhMZee+OxAykqHOY4zvZ/k=",
+    "zh:1343366e62832d5b4f70adc077cedfa6314584faa6e40fbd259710b2f1b88fcc",
+    "zh:15b6617479a36f3640105d84ce1b96f6e567ba03e452e3489602437cf94e4c02",
+    "zh:1847d651fed7f4cb3787d2c6a81bfa65a025f40183624e51eb997b8a24194b74",
+    "zh:21a4e41fcdd0497faee110dd719177a8755cde059e226569fd56a870a406c0c1",
+    "zh:71d46b7ee4b6423c205a001bc72143ff0f28a77cf2cc7fa15ad163082a6f651a",
+    "zh:86671d61f2b3ecc1bd86ccd866137841854aeaeb0847373864e4333bd5e64873",
+    "zh:8e952bccba751d7c578a306f276b06896b465dc92debf78065538abe3d221bd0",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:c5c31f58fb5bd6aebc6c662a4693640ec763cb3399cce0b592101cf24ece1625",
-    "zh:cc485410be43d6ad95d81b9e54cc4d2117aadf9bf5941165a9df26565d9cce42",
-    "zh:cebb89c74b6a3dc6780824b1d1e2a8d16a51e75679e14ad0b830d9f7da1a3a67",
-    "zh:e7dc427189cb491e1f96e295101964415cbf8630395ee51e396d2a811f365237",
+    "zh:b69c8c882dcaaa2f5e6a57acc659cb8a82c224395a69d34936e0cc3f2fbb72a7",
+    "zh:cf55d6b1f4306731d6c595541dade80e2abab9648dec8fcc9dffa65423d42186",
+    "zh:edc4afe6809be03b567f2a7604503a8033a78bd2150f937ed5ef3847109c016c",
+    "zh:ee6e28db6ed35b90ae4fddcd6d3186447b036f11904548db16db69e869d39651",
   ]
 }
 

--- a/terraform/rocketpool/cloudwatch.tf
+++ b/terraform/rocketpool/cloudwatch.tf
@@ -1,6 +1,6 @@
 module "cloudwatch_metric_alarms" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "3.1.0"
+  version = "3.2.0"
 
   for_each = {
     for key, val in try(local.aws_vars.cloudwatch, {}) :

--- a/terraform/rocketpool/iam.tf
+++ b/terraform/rocketpool/iam.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "eip_attach" {
       variable = "ec2:ResourceTag/Name"
 
       values = [
-        "${local.name_prefix}-node",
+        "${local.name_prefix}-${local.aws_vars.ec2.name}",
       ]
     }
   }
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "ebs_attach" {
       variable = "ec2:ResourceTag/Name"
 
       values = [
-        "${local.name_prefix}-node",
+        "${local.name_prefix}-${local.aws_vars.ec2.name}",
       ]
     }
   }
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "ebs_attach" {
 }
 
 resource "aws_iam_role" "node" {
-  name = "${local.name_prefix}-node"
+  name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
 
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 
@@ -133,19 +133,19 @@ resource "aws_iam_role" "node" {
   tags = merge(
     local.default_tags,
     {
-      Name = "${local.name_prefix}-node"
+      Name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
     },
   )
 }
 
 resource "aws_iam_instance_profile" "node" {
-  name = "${local.name_prefix}-node"
+  name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
   role = aws_iam_role.node.name
 
   tags = merge(
     local.default_tags,
     {
-      Name = "${local.name_prefix}-node"
+      Name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
     },
   )
 

--- a/terraform/rocketpool/nodes.tf
+++ b/terraform/rocketpool/nodes.tf
@@ -108,7 +108,7 @@ resource "aws_launch_template" "node" {
   tags = merge(
     local.default_tags,
     {
-      Name = "${local.name_prefix}-node"
+      Name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
     },
   )
 }
@@ -125,7 +125,7 @@ resource "aws_ebs_volume" "node_data" {
   tags = merge(
     local.default_tags,
     {
-      Name = "${local.name_prefix}-node"
+      Name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
     },
   )
 }
@@ -153,7 +153,7 @@ resource "aws_autoscaling_group" "node" {
     for_each = merge(
       local.default_tags,
       {
-        Name          = "${local.name_prefix}-node"
+        Name          = "${local.name_prefix}-${local.aws_vars.ec2.name}"
         eth_node_type = "core"
         eth_network   = try(local.node_vars.eth_network, "mainnet")
       },
@@ -176,7 +176,7 @@ resource "aws_eip" "node" {
   tags = merge(
     local.default_tags,
     {
-      Name = "${local.name_prefix}-node"
+      Name = "${local.name_prefix}-${local.aws_vars.ec2.name}"
     },
   )
 


### PR DESCRIPTION
- Fix terraform not using node name in aws resources
- Update providers
- Update TF modules