### PR TITLE
Update smartnode-install to v1.5.1

### DIFF
--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -62,4 +62,4 @@ jobs:
 
       - name: Run playbook
         id: ansible-playbook
-        run: ansible-playbook site.yml -e "POOL=mainnet-00" --skip-tags 'skipci'
+        run: ansible-playbook site.yml -e "POOL=mainnet-00" --skip-tags 'skipci' -vvv

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -42,5 +42,5 @@ rule "terraform_required_version" {
 plugin "aws" {
   enabled = true
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
-  version = "0.13.3"
+  version = "0.16.0"
 }

--- a/ansible/roles/base/tasks/firewall.yml
+++ b/ansible/roles/base/tasks/firewall.yml
@@ -22,8 +22,8 @@
     proto: "{{ rule.proto | default(omit) }}"
   loop:
     - {name: 'OpenSSH', comment: "Allow to OpenSSH Port"}
-    - {port: "{{ rocketpool.ports.gethP2pPort }}", proto: 'tcp', comment: "Allow ETH1 Discovery TCP"}
-    - {port: "{{ rocketpool.ports.gethP2pPort }}", proto: 'udp', comment: "Allow ETH1 Discovery UDP"}
+    - {port: "{{ rocketpool.ports.executionCommonP2pPort }}", proto: 'tcp', comment: "Allow ETH1 Discovery TCP"}
+    - {port: "{{ rocketpool.ports.executionCommonP2pPort }}", proto: 'udp', comment: "Allow ETH1 Discovery UDP"}
     - {port: "{{ rocketpool.ports.consensusCommonP2pPort }}", proto: 'tcp', comment: "Allow ETH2 Discovery TCP"}
     - {port: "{{ rocketpool.ports.consensusCommonP2pPort }}", proto: 'udp', comment: "Allow ETH2 Discovery UDP"}
     - {port: "{{ prometheus.node_exporter.port }}", proto: 'tcp', comment: "Allow prometheus to scrape node-exporter"}

--- a/ansible/roles/base/tasks/system.yml
+++ b/ansible/roles/base/tasks/system.yml
@@ -36,7 +36,7 @@
   ansible.builtin.user:
     name: "{{ rocketpool.user | default('rp') }}"
     shell: /bin/bash
-    uid: "{{ ( rocketpool.uid | default('1001') ) if lookup('env', 'CI') != 'true' else omit }}"
+    uid: "{{ (rocketpool.uid | default('1001')) if lookup('env', 'CI') != 'true' else omit }}"
 
 - name: System | Add rocketpool user to sudoers
   community.general.sudoers:

--- a/ansible/roles/rocketpool/tasks/install.yml
+++ b/ansible/roles/rocketpool/tasks/install.yml
@@ -2,7 +2,9 @@
 - name: Rocketpool Install | Set config execution parameters
   ansible.builtin.set_fact:
     ROCKETPOOL_CLI_CONFIG: "{{ ROCKETPOOL_CLI_CONFIG | default('')
-                             + '--' + option.name + ' ' + ( option.value | default('') ) + ' '
+                             + '--' + option.name
+                             + (' ' if option.value != 'false' else '=')
+                             + (option.value | default('')) + ' '
                            }}"
   loop: "{{ rocketpool.config }}"
   loop_control:
@@ -15,13 +17,23 @@
       - "Executing config command:"
       - "{{ rocketpool_bin }} service config {{ ROCKETPOOL_CLI_CONFIG }}"
 
-- name: Rocketpool Install | Create rocketpool directory
+- name: Rocketpool Install | Create rocketpool directories
+  become: true
   ansible.builtin.file:
     state: directory
-    path: "{{ rocketpool_user_home }}/.rocketpool"
-    owner: "{{ rocketpool.user | default('rp') }}"
-    group: "{{ rocketpool.user | default('rp') }}"
+    path: "{{ dir.path }}"
+    owner: "{{ dir.owner }}"
+    group: "{{ dir.group }}"
     mode: 0700
+  loop:
+    - { path: "{{ rocketpool_user_home }}/.rocketpool", owner: "{{ rocketpool.user | default('rp') }}", group: "{{ rocketpool.user | default('rp') }}" }
+    - { path: "{{ eth.secrets.dataDir }}", owner: "{{ rocketpool.user | default('rp') }}", group: "{{ rocketpool.user | default('rp') }}" }
+    - { path: "{{ eth.eth1.dataDir }}", owner: 'root', group: 'root' }
+    - { path: "{{ eth.eth2.dataDir }}", owner: 'root', group: 'root' }
+    - { path: "{{ grafana.dataDir }}", owner: "{{ rocketpool.user | default('rp') }}", group: "{{ rocketpool.user | default('rp') }}" }
+  loop_control:
+    loop_var: dir
+    label: "{{ dir.path }}"
 
 - name: Rocketpool Install | Execute rocketpool service config command
   become: true
@@ -51,7 +63,7 @@
 - name: Rocketpool Install | Execute rocketpool service install command
   become: true
   become_user: "{{ rocketpool.user | default('rp') }}"
-  ansible.builtin.command: "{{ rocketpool_bin }} service install -y --no-deps --version {{ rocketpool_version }}"
+  ansible.builtin.command: "{{ rocketpool_bin }} service install -y --no-deps --version {{ rocketpool_version }} --verbose"
   args:
     chdir: "{{ rocketpool_user_home }}/.rocketpool"
   vars:

--- a/ansible/roles/rocketpool/tasks/post_install.yml
+++ b/ansible/roles/rocketpool/tasks/post_install.yml
@@ -2,7 +2,7 @@
 - name: Rocketpool Post Install | Check ETH1 port
   ansible.builtin.wait_for:
     host: 0.0.0.0
-    port: "{{ rocketpool.ports.gethP2pPort }}"
+    port: "{{ rocketpool.ports.executionCommonP2pPort }}"
     timeout: 300
     delay: 2
 

--- a/ansible/setup-rocketpool.yml
+++ b/ansible/setup-rocketpool.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Setup Rocketpool Playbook
+  hosts: localhost
   connection: local
   gather_facts: true
   become: true

--- a/ansible/setup-system.yml
+++ b/ansible/setup-system.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Setup System Playbook
+  hosts: localhost
   connection: local
   gather_facts: true
   become: true

--- a/terraform/rocketpool/.terraform.lock.hcl
+++ b/terraform/rocketpool/.terraform.lock.hcl
@@ -2,10 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "4.16.0"
+  version     = "4.27.0"
   constraints = ">= 3.54.0, >= 3.63.0, >= 4.8.0, >= 4.9.0"
   hashes = [
-    "h1:u1SMSE9I4DL7ODSNbNvNZbOpXm9w6GO34i82YHm/zL0=",
+    "h1:w3j7YomUQ9IfRp3MUuY0+hFX1T1cawZoj0Xsc1a46bU=",
+    "zh:0f5ade3801fec487641e4f7d81e28075b716c787772f9709cc2378d20f325791",
+    "zh:19ffa83be6b6765a4f821a17b8d260dd0f192a6c40765fa53ac65fd042cb1f65",
+    "zh:3ac89d33ff8ca75bdc42f31c63ce0018ffc66aa69917c18713e824e381950e4e",
+    "zh:81a199724e74992c8a029a968d211cb45277d95a2e88d0f07ec85127b6c6849b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2e2c851a37ef97bbccccd2e686b4d016abe207a7f56bff70b10bfdf8ed1cbfd",
+    "zh:baf844def338d77f8a3106b1411a1fe22e93a82e3dc51e5d33b766f741c4a6a3",
+    "zh:bc33137fae808f91da0a9de7031cbea77d0ee4eefb4d2ad6ab7f58cc2111a7ff",
+    "zh:c960ae2b33c8d3327f67a3db5ce1952315146d69dfc3f1b0922242e2b218eec8",
+    "zh:f3ea1a25797c79c035463a1188a6a42e131f391f3cb714975ce49ccd301cda07",
+    "zh:f7e77c871d38236e5fedee0086ff77ff396e88964348c794cf38e578fcc00293",
+    "zh:fb338d5dfafab907b8608bd66cad8ca9ae4679f8c62c2435c2056a38b719baa2",
   ]
 }
 
@@ -18,9 +30,21 @@ provider "registry.terraform.io/hashicorp/external" {
 }
 
 provider "registry.terraform.io/hashicorp/http" {
-  version = "2.1.0"
+  version = "3.0.1"
   hashes = [
-    "h1:HmUcHqc59VeHReHD2SEhnLVQPUKHKTipJ8Jxq67GiDU=",
+    "h1:4N7YctkZrU+K2AvUF57c1qUvoD92bBJj6vXwf/FKMhM=",
+    "zh:3b161998147d8cc3986a1580ddb065009ab628747424934cbcb9d221783541f8",
+    "zh:62c78b565cde08d8e3b98e8138cd8e46b50fdc2ddc560ac1f62b5646ce8e9b1f",
+    "zh:69ba560cd6360a285e83e1c220ab140d3119371850756ff2ed0abe39d362ea49",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:95f38aebfa176a3424a329bc0f2e958bcf5a1f98d91dee21a436ca670fb2d570",
+    "zh:97eae729eb859948201d4393761f5c1a7ffe84046473527f65163f062d9af5d9",
+    "zh:b42de839114707e2fcfdf5ebf3a89129e5e17ebb5f84651c5775daecd776dc3b",
+    "zh:c47fa93605b8378504008534e0057e295d209a2128553c7b1bcc4fc7f6efafa2",
+    "zh:d9d4fe5143f80c1ccf22b055f069445ab7470942bb46027dadda8f3bc62d2780",
+    "zh:f051820764c50f4736d21e40d9b13a1ffde678748a9e6e1ef22a26adf27db9bf",
+    "zh:f67c9b73998fce13e94623be9b7afe89b30e3e6d34b504f765a344b11b8808b8",
+    "zh:f7d255dac5a73d30c7e629699fdf064decf705cd701d29e2120cef7bf0fb1d7f",
   ]
 }
 
@@ -48,8 +72,20 @@ provider "registry.terraform.io/hashicorp/template" {
 }
 
 provider "registry.terraform.io/hashicorp/tls" {
-  version = "3.4.0"
+  version = "4.0.1"
   hashes = [
-    "h1:oyllIA9rNGCFtClSyBitUIzCXdnKtspVepdsvpLlfys=",
+    "h1:oyckFNWXgZtgUanWHbNyz3txRgXYkDpCsTLSv5JSD1I=",
+    "zh:1aa2e4c07ddf87f7bda65a4a0f3b45c3edfbe983768d49a105f7ab9f2e4f8320",
+    "zh:1b7993daaf659dec421043ccf2dea021972ebacf47e5da3387e1ef35a0ffecbe",
+    "zh:1c40b056af93fe792fd468a96f317a6ce918849799906cf619a1b8cf01e79ccb",
+    "zh:3874421e4c975e987ade5bdece6d1eacd41065841c82856cc12fde405ea2fe38",
+    "zh:4f27e1a90d779ac4bbdbd3db735b4777a90aefc8005905a8ed450bb517c323db",
+    "zh:b4eb5438dc4bfbed7223c0044b775a210d52b631a9f37d884d567a3eacc31b92",
+    "zh:b9808ee16fa06b7113a72c8d74f1cb322d0e7364fc34ba4bfdd0424ef7fd93d8",
+    "zh:bc5b1913fe841a0d40f28ff70d76e1c22fa3f469ae28011422d12c6001dcb954",
+    "zh:bdba092ae2939cb7e28380c5fd4a33ee96bead1abadbf9ec95d559cea8c04c3c",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f80791f95f0ea5b332913e533c79ed4820e8c9243c508d8c7d6240b212160aaa",
+    "zh:fe34ecc33c990f045ca5e3828e8aeb8ee86c9072e098e0ac0e4b47cbcb01edc0",
   ]
 }

--- a/terraform/rocketpool/bundle.tf
+++ b/terraform/rocketpool/bundle.tf
@@ -35,7 +35,7 @@ resource "local_file" "tar_sh" {
 }
 
 data "external" "tar_sh" {
-  program    = [local_file.tar_sh.filename, "-cvzf", "${path.module}/ansible-${local.rp_vars.rocketpool.version}.tar.gz", "${join(" ", local.bundle_files)}"]
+  program    = [local_file.tar_sh.filename, "-cvzf", "${path.module}/ansible-${local.rp_vars.rocketpool.version}.tar.gz", join(" ", local.bundle_files)]
   depends_on = [data.template_file.tar_sh, local_file.local_update]
 }
 

--- a/terraform/rocketpool/cloudwatch.tf
+++ b/terraform/rocketpool/cloudwatch.tf
@@ -1,6 +1,6 @@
 module "cloudwatch_metric_alarms" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "3.2.0"
+  version = "3.3.0"
 
   for_each = {
     for key, val in try(local.aws_vars.cloudwatch, {}) :

--- a/terraform/rocketpool/sns.tf
+++ b/terraform/rocketpool/sns.tf
@@ -1,7 +1,7 @@
 module "notify_slack" {
   count   = try(length(keys(local.aws_vars.sns)), 0) > 0 ? 1 : 0
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "5.1.0"
+  version = "5.3.0"
 
   lambda_function_name = "cloudstruct_rocketpool_${local.pool}_notify_slack"
   sns_topic_name       = try(local.aws_vars.sns.slack.topic_name, null)

--- a/terraform/rocketpool/vpc.tf
+++ b/terraform/rocketpool/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.0"
+  version = "3.14.2"
 
   name = local.name_prefix
   cidr = local.aws_vars.vpc.cidr

--- a/vars/pools/mainnet-00/rocketpool.yaml
+++ b/vars/pools/mainnet-00/rocketpool.yaml
@@ -5,41 +5,47 @@ rocketpool:
   # user: 'rp'  # Optional: Defaults to 'rp'
   # uid: '1001' # Optional: Defaults to '1001'
   ports:
-    beaconNodeMetrics: 9100
-    validatorClientMetrics: 9101
-    nodeMetrics: 9102
-    watchTowerMetrics: 9104
-    fallbackExecutionCommonHttpPort: 8545
-    fallbackExecutionCommonWsPort: 8546
+    beaconNodeMetricsPort: 9100
     consensusCommonP2pPort: 9001
     consensusCommonApiPort: 5052
-    prysmRpcPort: 5053
+    executionClientMetricsPort: 9105
+    executionCommonEnginePort: 8551
     executionCommonHttpPort: 8545
+    executionCommonP2pPort: 30303
     executionCommonWsPort: 8546
-    gethP2pPort: 30303
+    mevBoostPort: 18550
+    nodeMetricsPort: 9102
+    prysmRpcPort: 5053
+    validatorClientMetricsPort: 9101
+    watchTowerMetricsPort: 9104
   # https://github.com/rocket-pool/smartnode-install/releases
-  version: 'v1.4.3'
+  version: 'v1.5.1'
   config:
     # Uncomment and fill in the options you require
     # See 'rocketpool service config --help' for a list of all possible parameter input values and defaults
     # - { name: 'executionClientMode', value: '' }
     # - { name: 'executionClient', value: '' }
-    # - { name: 'useFallbackExecutionClient' }
-    # - { name: 'fallbackExecutionClientMode', value: '' }
-    # - { name: 'fallbackExecutionClient', value: '' }
+    # - { name: 'useFallbackClients', value: 'false' }
+    # - { name: 'fallbackNormal-ecHttpUrl', value: '' }
+    # - { name: 'fallbackNormal-ccHttpUrl', value: '' }
+    # - { name: 'fallbackPrysm-ecHttpUrl', value: '' }
+    # - { name: 'fallbackPrysm-ccHttpUrl', value: '' }
+    # - { name: 'fallbackPrysm-jsonRpcUrl', value: '' }
     # - { name: 'reconnectDelay', value: '' }
     # - { name: 'consensusClientMode', value: '' }
     # - { name: 'consensusClient', value: '' }
     # - { name: 'externalConsensusClient', value: '' }
-    # - { name: 'enableMetrics' }
-    # - { name: 'bnMetricsPort', value: "{{ rocketpool.ports.beaconNodeMetrics }}" }
-    # - { name: 'vcMetricsPort', value: "{{ rocketpool.ports.validatorClientMetrics }}" }
-    # - { name: 'nodeMetricsPort', value: "{{ rocketpool.ports.nodeMetrics }}" }
+    # - { name: 'enableMetrics', value: 'false' }
+    # - { name: 'enableBitflyNodeMetrics', value: 'false' }
+    # - { name: 'bitflyNodeMetrics-secret', value: '' }
+    # - { name: 'bitflyNodeMetrics-endpoint', value: 'https://beaconcha.in/api/v1/client/metrics' }
+    # - { name: 'bitflyNodeMetrics-machineName', value: 'Smartnode' }
+    # - { name: 'ecMetricsPort', value: "{{ rocketpool.ports.executionClientMetricsPort }}" }
+    # - { name: 'bnMetricsPort', value: "{{ rocketpool.ports.beaconNodeMetricsPort }}" }
+    # - { name: 'vcMetricsPort', value: "{{ rocketpool.ports.validatorClientMetricsPort }}" }
+    # - { name: 'nodeMetricsPort', value: "{{ rocketpool.ports.nodeMetricsPort }}" }
     # - { name: 'exporterMetricsPort', value: "{{ prometheus.node_exporter.port }}" }
-    # - { name: 'watchtowerMetricsPort', value: "{{ rocketpool.ports.watchTowerMetrics }}" }
-    # - { name: 'fallbackPocket-gatewayID', value: '' }
-    # - { name: 'fallbackPocket-containerTag', value: '' }
-    # - { name: 'fallbackPocket-additionalFlags', value: '' }
+    # - { name: 'watchtowerMetricsPort', value: "{{ rocketpool.ports.watchTowerMetricsPort }}" }
     # - { name: 'lighthouse-maxPeers', value: '' }
     # - { name: 'lighthouse-containerTag', value: '' }
     # - { name: 'lighthouse-additionalBnFlags', value: '' }
@@ -48,9 +54,7 @@ rocketpool:
     # - { name: 'native-consensusClient', value: '' }
     # - { name: 'native-ccHttpUrl', value: '' }
     # - { name: 'native-validatorRestartCommand', value: '' }
-    # - { name: 'pocket-gatewayID', value: '' }
-    # - { name: 'pocket-containerTag', value: '' }
-    # - { name: 'pocket-additionalFlags', value: '' }
+    # - { name: 'native-validatorStopCommand', 'stop-validator.sh' }
     # - { name: 'consensusCommon-graffiti', value: '' }
     # - { name: 'consensusCommon-checkpointSyncUrl', value: '' }
     # - { name: 'consensusCommon-p2pPort', value: "{{ rocketpool.ports.consensusCommonP2pPort }}" }
@@ -77,34 +81,43 @@ rocketpool:
     # - { name: 'teku-containerTag', value: '' }
     # - { name: 'teku-additionalBnFlags', value: '' }
     # - { name: 'teku-additionalVcFlags', value: '' }
+    # - { name: 'smartnode-archiveECUrl', value: '' }
     # - { name: 'smartnode-network', value: '' }
     # - { name: 'smartnode-projectName', value: '' }
     - { name: 'smartnode-dataPath', value: "{{ eth.secrets.dataDir }}" }
     # - { name: 'smartnode-manualMaxFee', value: '' }
     # - { name: 'smartnode-priorityFee', value: '' }
     # - { name: 'smartnode-rplClaimGasThreshold', value: '' }
+    # - { name: 'smartnode-rewardsTreeMode', value: 'download' }
     # - { name: 'smartnode-minipoolStakeGasThreshold', value: '' }
+    # - { name: 'smartnode-watchtowerPath', value: "{{ rocketpool_user_home }}/.rocketpool/watchtower }}" }
+    # - { name: 'smartnode-web3StorageApiToken', value: "" }
+    # - { name: 'executionCommon-enginePort', value: "{{ rocketpool.ports.executionCommonEnginePort }}" }
     # - { name: 'executionCommon-httpPort', value: "{{ rocketpool.ports.executionCommonHttpPort }}" }
+    # - { name: 'executionCommon-p2pPort', value: "{{ rocketpool.ports.executionCommonP2pPort }}" }
     # - { name: 'executionCommon-wsPort', value: "{{ rocketpool.ports.executionCommonWsPort }}" }
     # - { name: 'executionCommon-openRpcPorts' }
-    # - { name: 'geth-cache', value: '' }
-    # - { name: 'geth-maxPeers', value: '' }
-    # - { name: 'geth-p2pPort', value: "{{ rocketpool.ports.gethP2pPort }}" }
-    # - { name: 'geth-ethstatsLabel', value: '' }
-    # - { name: 'geth-ethstatsLogin', value: '' }
+    # - { name: 'besu-containerTag', value: '' }
+    # - { name: 'besu-jvmHeapSize', value: '0' }
+    # - { name: 'besu-maxPeers', value: '25' }
+    # - { name: 'besu-maxBackLayers', value: '512' }
+    # - { name: 'geth-cache', value: '4096' }
+    # - { name: 'geth-maxPeers', value: '25' }
     # - { name: 'geth-containerTag', value: '' }
     # - { name: 'geth-additionalFlags', value: '' }
-    # - { name: 'infura-projectID', value: '' }
-    # - { name: 'infura-containerTag', value: '' }
-    # - { name: 'infura-additionalFlags', value: '' }
     # - { name: 'externalExecution-httpUrl', value: '' }
     # - { name: 'externalExecution-wsUrl', value: '' }
-    # - { name: 'fallbackExecutionCommon-httpPort', value: "{{ rocketpool.ports.fallbackExecutionCommonHttpPort }}" }
-    # - { name: 'fallbackExecutionCommon-wsPort', value: "{{ rocketpool.ports.fallbackExecutionCommonWsPort }}" }
-    # - { name: 'fallbackExecutionCommon-openRpcPorts' }
+    # - { name: 'nethermind-cache', value: '2048' }
+    # - { name: 'nethermind-containerTag', value: '' }
+    # - { name: 'nethermind-maxPeers', value: '25' }
+    # - { name: 'nethermind-pruneMemSize', value: '2048' }
+    # - { name: 'nethermind-additionalFlags', value: '' }
     # - { name: 'nimbus-maxPeers', value: '' }
     # - { name: 'nimbus-containerTag', value: '' }
     # - { name: 'nimbus-additionalFlags', value: '' }
+    # - { name: 'teku-containerTag', value: '' }
+    # - { name: 'teku-jvmHeapSize', value: '0' }
+    # - { name: 'teku-maxPeers', value: '100' }
     # - { name: 'externalPrysm-httpUrl', value: '' }
     # - { name: 'externalPrysm-jsonRpcUrl', value: '' }
     # - { name: 'externalPrysm-graffiti', value: '' }
@@ -115,24 +128,25 @@ rocketpool:
     # - { name: 'prometheus-openPort' }
     - { name: 'prometheus-containerTag', value: "{{ prometheus.version }}" }
     # - { name: 'prometheus-additionalFlags', value: '' }
-    # - { name: 'fallbackInfura-projectID', value: '' }
-    # - { name: 'fallbackInfura-containerTag', value: '' }
-    # - { name: 'fallbackInfura-additionalFlags', value: '' }
-    # - { name: 'fallbackExternalExecution-httpUrl', value: '' }
-    # - { name: 'fallbackExternalExecution-wsUrl', value: '' }
     # - { name: 'externalTeku-httpUrl', value: '' }
     # - { name: 'externalTeku-graffiti', value: '' }
     # - { name: 'externalTeku-containerTag', value: '' }
     # - { name: 'externalTeku-additionalVcFlags', value: '' }
     # - { name: 'grafana-port', value: "{{ grafana.port }}" }
     - { name: 'grafana-containerTag', value: "{{ grafana.version }}" }
+    # - { name: 'mevBoost-mode', value: 'local' }
+    # - { name: 'mevBoost-port', value: "{{ rocketpool.ports.mevBoostPort }}" }
+    # - { name: 'mevBoost-relays', value: '' }
+    # - { name: 'mevBoost-containerTag', value: '' }
+    # - { name: 'mevBoost-additionalFlags', value: '' }
+    # - { name: 'mevBoost-externalUrl', value: '' }
 
 grafana:
   # Where to store grafana persistent data (/data is EBS volume mount location)
   dataDir: '/data/grafana'
   port: 3100
   # https://grafana.com/docs/grafana/latest/release-notes/
-  version: '9.0.2'
+  version: '9.1.1'
 
 eth:
   network: 'mainnet'
@@ -145,7 +159,7 @@ eth:
 
 prometheus:
   # https://github.com/prometheus/prometheus/releases
-  version: 'v2.36.2'
+  version: 'v2.38.0'
   # Where to store Prometheus persistent data. (/data is EBS volume mount location)
   dataDir: '/data/prometheus'
   port: 9091


### PR DESCRIPTION
- Update Rocketpool Smartnode Installer to v1.5.1
- Update config options to match Rocketpool Smartnode Installer 1.5.x
- Update tflint aws plugin to v0.16.0
- Update Terraform modules to latest versions
- Update Grafana to v9.1.1
- Update Prometheus to v2.38.0
- Fix ansible spacing to conform to latest ansible-lint recommendations